### PR TITLE
Accelerated bond calculation

### DIFF
--- a/src/molara/Structure/structure.py
+++ b/src/molara/Structure/structure.py
@@ -104,7 +104,7 @@ class Structure:
         coordinates = np.array([atom.position for atom in self.atoms])
 
         max_distance = 2.0 * vdw_radii.max() / 1.75
-        tree = spatial.KDTree(coordinates)
+        tree = spatial.cKDTree(coordinates)
 
         for i, j in tree.query_pairs(max_distance):
             if i > j:


### PR DESCRIPTION
See benchmark problem in issue #309.
For the 25x25x25 supercell, Molara used to take ~18 seconds only for the calculation of the bonds (longer than the subsequent rendering!).
For the same problem, it now takes ~1.85 seconds. This acceleration is achieved by using the `query_pairs` routine from `scipy.spatial.cKDTree`. With this, the rendering is the bottleneck again (as it should be, I guess).

Closes #309.