### PR TITLE
Add .log and .trj to xyzimporter for importing trajectories

### DIFF
--- a/src/molara/Structure/io/importer.py
+++ b/src/molara/Structure/io/importer.py
@@ -443,6 +443,8 @@ class GeneralImporter(MoleculesImporter):
 
     _IMPORTER_BY_SUFFIX: Mapping[str, Any] = {
         ".xyz": XyzImporter,
+        ".trj": XyzImporter,
+        ".log": XyzImporter,
         ".coord": CoordImporter,
         ".POSCAR": PoscarImporter,
         ".CONTCAR": PoscarImporter,


### PR DESCRIPTION
Added the ability to parse .log and .trj files by using the same code as the xyz importer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded file import capabilities to include ".trj" and ".log" extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->