### PR TITLE
Limit `matplotlib` version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ maintainers = [
 dependencies = [
     "PyOpenGL",
     "PySide6<=6.6.2",
-    "matplotlib",
+    "matplotlib<3.9.0",
     "numpy",
     "pyrr",
     "scipy",


### PR DESCRIPTION
Tests fail on main (ubuntu) due to a recent update of `matplotlib`. This PR limits the version number. 