### PR TITLE
Fix deprecation warnings in Pytest

### DIFF
--- a/src/molara/Gui/structure_widget.py
+++ b/src/molara/Gui/structure_widget.py
@@ -276,7 +276,7 @@ class StructureWidget(QOpenGLWidget):
 
         :param event: mouse event (such as left click, right click...)
         """
-        if event.x() not in range(self.width()) or event.y() not in range(self.height()):
+        if event.position().x() not in range(self.width()) or event.position().y() not in range(self.height()):
             return
 
         if event.button() == Qt.MouseButton.LeftButton:
@@ -321,11 +321,11 @@ class StructureWidget(QOpenGLWidget):
         :param event: mouse event (such as left click, right click...)
         """
         if self.width() >= self.height():
-            self.position[0] = (event.x() * 2 - self.width()) / self.width()
-            self.position[1] = -(event.y() * 2 - self.height()) / self.width()
+            self.position[0] = (event.position().x() * 2 - self.width()) / self.width()
+            self.position[1] = -(event.position().y() * 2 - self.height()) / self.width()
         else:
-            self.position[0] = (event.x() * 2 - self.width()) / self.height()
-            self.position[1] = -(event.y() * 2 - self.height()) / self.height()
+            self.position[0] = (event.position().x() * 2 - self.width()) / self.height()
+            self.position[1] = -(event.position().y() * 2 - self.height()) / self.height()
         self.position = np.array(self.position, dtype=np.float32)
 
     def mouseReleaseEvent(self, event: QMouseEvent) -> None:  # noqa: N802
@@ -523,7 +523,7 @@ class StructureWidget(QOpenGLWidget):
         if len(self.structures) != 1:
             return
         self.makeCurrent()
-        selected_sphere_id = self.identify_selected_sphere(event.x(), event.y())
+        selected_sphere_id = self.identify_selected_sphere(event.position().x(), event.position().y())
 
         selected_spheres_list = (
             self.measurement_selected_spheres if purpose == MEASUREMENT else self.builder_selected_spheres

--- a/tests/molara/gui/test_structure_widget.py
+++ b/tests/molara/gui/test_structure_widget.py
@@ -112,10 +112,16 @@ class WorkaroundTestStructureWidget:
         event = QMouseEvent(
             QEvent.MouseButtonPress,  # Event type
             QPoint(50, 50),  # Position
+            QPoint(0, 0),  # Global (screen) position
             Qt.LeftButton,  # Button
             Qt.LeftButton,  # Buttons (pressed buttons)
             Qt.NoModifier,  # Modifiers (keyboard modifiers)
         )
+        # Comment on the constructor of QMouseEvent:
+        # The global position is necessary to avoid the use of a deprecated method.
+        # The global position is not used in the test, so it is set to (0, 0).
+        # Should this cause problems in the future, we need to
+        # figure out how to set the global position correctly.
         structure_widget.update_selected_atoms(MEASUREMENT, event)
 
         measurement_selected_spheres = structure_widget.measurement_selected_spheres


### PR DESCRIPTION
Ready to merge!
The missing lines in the patch coverage are rather exotic special cases, so let's please ignore that. 