### PR TITLE
Undo "Bump actions/{upload/download}-artifact from 3 to 4"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           pip install build
           python -m build --sdist
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
           path: dist/*.tar.gz
 
@@ -56,7 +56,7 @@ jobs:
           CIBW_BUILD: cp${{ matrix.python-version }}-*
 
       - name: Save artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
 
@@ -73,7 +73,7 @@ jobs:
           python-version: 3.12
 
       - name: Get build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist


### PR DESCRIPTION
Temporary fix for upload problems with `upload-artifact` for latest release.

 https://github.com/actions/upload-artifact/issues/478