### PR TITLE
Drop `python3.9` support

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.10", "3.12"]
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-14, windows-latest]
-        python-version: ["39", "310", "311", "312"]
+        python-version: ["310", "311", "312"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,12 +21,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         version:
-          - { python: "3.9", resolution: lowest-direct, extra: "tests,crystal,compchem" }
+          - { python: "3.10", resolution: lowest-direct, extra: "tests,crystal,compchem" }
           - { python: "3.12", resolution: highest, extra: "tests,strict,crystal,compchem" }
         # Add macOS without optional dependencies, running only on python 3.10
         include:
           - os: macos-latest
-            version: { python: "3.10", resolution: highest, extra: "tests,strict" }
+            version: { python: "3.11", resolution: highest, extra: "tests,strict" }
 
     runs-on: ${{ matrix.os }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ molara = "molara.__main__:main"
 
 [tool.ruff]
 exclude = ["ui_*",]
-target-version = "py39"
+target-version = "py310"
 line-length = 120
 lint.select = ["ALL"]
 lint.ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "pyrr>=0.10.3",
     "scipy>=1.7.0",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 readme = "README.md"
 license = {file = "LICENSE"}
 keywords = ["analysis, science, structure, visualisation"]
@@ -45,7 +45,6 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,6 @@ lint.ignore = [
   "PTH123", # `open()` should be replaced by `Path.open()`
   "S101",   # Use of assert detected
   ]
-lint.isort.required-imports = ["from __future__ import annotations"]
 
 [tool.mypy]
 exclude = ["ui_*"]

--- a/src/molara/gui/builder.py
+++ b/src/molara/gui/builder.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, Callable, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import numpy as np
 from PySide6.QtWidgets import QDialog, QTableWidgetItem
@@ -15,6 +15,8 @@ from molara.structure.molecule import Molecule
 from molara.structure.molecules import Molecules
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from PySide6.QtWidgets import QMainWindow
     from typing_extensions import ParamSpec
 

--- a/src/molara/gui/measuring_tool_dialog.py
+++ b/src/molara/gui/measuring_tool_dialog.py
@@ -79,7 +79,7 @@ class MeasurementDialog(QDialog):
             _set_item = obj.setHorizontalHeaderItem if horizontal else obj.setVerticalHeaderItem
             if colors is None:
                 colors = [None] * len(labels)
-            for i, (label_i, color_i) in enumerate(zip(labels, colors, strict=False)):
+            for i, (label_i, color_i) in enumerate(zip(labels, colors, strict=True)):
                 item = QTableWidgetItem(label_i)
                 if align_right:
                     item.setTextAlignment(Qt.AlignRight | Qt.AlignVCenter)

--- a/src/molara/gui/measuring_tool_dialog.py
+++ b/src/molara/gui/measuring_tool_dialog.py
@@ -79,7 +79,7 @@ class MeasurementDialog(QDialog):
             _set_item = obj.setHorizontalHeaderItem if horizontal else obj.setVerticalHeaderItem
             if colors is None:
                 colors = [None] * len(labels)
-            for i, (label_i, color_i) in enumerate(zip(labels, colors)):
+            for i, (label_i, color_i) in enumerate(zip(labels, colors, strict=False)):
                 item = QTableWidgetItem(label_i)
                 if align_right:
                     item.setTextAlignment(Qt.AlignRight | Qt.AlignVCenter)

--- a/src/molara/structure/crystal.py
+++ b/src/molara/structure/crystal.py
@@ -102,7 +102,7 @@ class Crystal(Structure):
         for atomic_number_i, position_i in zip(
             self.atomic_nums_unitcell,
             self.coords_unitcell,
-            strict=False,
+            strict=True,
         ):
             self.atomic_nums_supercell = np.append(
                 self.atomic_nums_supercell,

--- a/src/molara/structure/crystal.py
+++ b/src/molara/structure/crystal.py
@@ -102,6 +102,7 @@ class Crystal(Structure):
         for atomic_number_i, position_i in zip(
             self.atomic_nums_unitcell,
             self.coords_unitcell,
+            strict=False,
         ):
             self.atomic_nums_supercell = np.append(
                 self.atomic_nums_supercell,

--- a/src/molara/structure/io/exporter.py
+++ b/src/molara/structure/io/exporter.py
@@ -17,14 +17,6 @@ if TYPE_CHECKING:
 __copyright__ = "Copyright 2024, Molara"
 
 
-class FileExporterError(Exception):
-    """Base class for errors occurring when loading molecules from file."""
-
-
-class FileFormatError(FileExporterError):
-    """Raised when the file format is wrong or unsupported."""
-
-
 class StructureExporter(ABC):
     """Base class for structure exporters."""
 

--- a/src/molara/structure/io/importer.py
+++ b/src/molara/structure/io/importer.py
@@ -15,6 +15,7 @@ from molara.structure.io.importer_crystal import PoscarImporter, PymatgenImporte
 from molara.structure.molecule import Molecule
 from molara.structure.molecules import Molecules
 from molara.structure.mos import Mos
+from molara.util.exceptions import FileFormatError, FileImporterError
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -31,14 +32,6 @@ if TYPE_CHECKING:
 __copyright__ = "Copyright 2024, Molara"
 
 bohr_to_angstrom = 5.29177210903e-1
-
-
-class FileImporterError(Exception):
-    """Base class for errors occurring when loading molecules from file."""
-
-
-class FileFormatError(FileImporterError):
-    """Raised when the file format is wrong or unsupported."""
 
 
 class MoleculesImporter(ABC):

--- a/src/molara/structure/io/importer_crystal.py
+++ b/src/molara/structure/io/importer_crystal.py
@@ -13,7 +13,7 @@ import numpy as np
 from molara.structure.atom import element_symbol_to_atomic_number
 from molara.structure.crystal import Crystal
 from molara.structure.crystals import Crystals
-from molara.structure.io.exceptions import FileFormatError
+from molara.util.exceptions import FileFormatError
 
 if TYPE_CHECKING:
     from os import PathLike

--- a/src/molara/structure/io/importer_crystal.py
+++ b/src/molara/structure/io/importer_crystal.py
@@ -150,7 +150,7 @@ class PoscarImporter(Importer):
         atomic_numbers = [element_symbol_to_atomic_number(symb) for symb in species]
 
         atomic_numbers_extended = []
-        for num, an in zip(numbers, atomic_numbers, strict=False):
+        for num, an in zip(numbers, atomic_numbers, strict=True):
             atomic_numbers_extended.extend(num * [an])
 
         scale_unitcell_to_volume = scale < 0

--- a/src/molara/structure/io/importer_crystal.py
+++ b/src/molara/structure/io/importer_crystal.py
@@ -150,7 +150,7 @@ class PoscarImporter(Importer):
         atomic_numbers = [element_symbol_to_atomic_number(symb) for symb in species]
 
         atomic_numbers_extended = []
-        for num, an in zip(numbers, atomic_numbers):
+        for num, an in zip(numbers, atomic_numbers, strict=False):
             atomic_numbers_extended.extend(num * [an])
 
         scale_unitcell_to_volume = scale < 0

--- a/src/molara/util/exceptions.py
+++ b/src/molara/util/exceptions.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 class FileImporterError(Exception):
     """base class for errors occurring when loading molecules from file."""
 
+class FileExporterError(Exception):
+    """Base class for errors occurring when loading molecules from file."""
 
-class FileFormatError(FileImporterError):
+class FileFormatError(ValueError):
     """raised when the file format is wrong or unsupported."""

--- a/src/molara/util/exceptions.py
+++ b/src/molara/util/exceptions.py
@@ -6,8 +6,10 @@ from __future__ import annotations
 class FileImporterError(Exception):
     """base class for errors occurring when loading molecules from file."""
 
+
 class FileExporterError(Exception):
     """Base class for errors occurring when loading molecules from file."""
+
 
 class FileFormatError(ValueError):
     """raised when the file format is wrong or unsupported."""

--- a/tests/molara/rendering/test_buffers.py
+++ b/tests/molara/rendering/test_buffers.py
@@ -53,12 +53,12 @@ class WorkaroundTestBuffers:
             sphere_colors,
         )
 
-        assert isinstance(vao, (np.integer, int))
+        assert isinstance(vao, np.integer | int)
         assert isinstance(buffers, list)
         # len(buffers) must always be 4.
         assert len(buffers) == 4  # noqa: PLR2004
         for i in range(4):
-            assert isinstance(buffers[i], (np.integer, int))
+            assert isinstance(buffers[i], np.integer | int)
 
     def _test_setup_vao_numbers(self) -> None:
         """Test the setup_vao_numbers function of the buffers module."""
@@ -69,9 +69,9 @@ class WorkaroundTestBuffers:
         positions_3d = np.array([[0, -0, 0], [1, 1, -1], [4, -5, 6], [-7, 8, 9], [-10, -11, -12]], dtype=np.float32)
         self.openGLWidget.makeCurrent()
         (vao, buffers) = setup_vao_numbers(digits, positions_3d)
-        assert isinstance(vao, (np.integer, int))
+        assert isinstance(vao, np.integer | int)
         assert isinstance(buffers, list)
         # len(buffers) must always be 2.
         assert len(buffers) == 2  # noqa: PLR2004
         for i in range(2):
-            assert isinstance(buffers[i], (np.integer, int))
+            assert isinstance(buffers[i], np.integer | int)

--- a/tests/molara/structure/io/test_importer_crystal.py
+++ b/tests/molara/structure/io/test_importer_crystal.py
@@ -10,8 +10,8 @@ import pytest
 from numpy.testing import assert_almost_equal, assert_array_equal
 
 from molara.structure.crystals import Crystals
-from molara.structure.io.exceptions import FileFormatError
 from molara.structure.io.importer import PoscarImporter, PymatgenImporter, VasprunImporter
+from molara.util.exceptions import FileFormatError
 
 if TYPE_CHECKING:
     from molara.structure.crystal import Crystal

--- a/tests/molara/structure/test_drawer.py
+++ b/tests/molara/structure/test_drawer.py
@@ -41,7 +41,7 @@ class TestDrawer(TestCase):
         self.coords_glucose = xyz_data_glucose[:, 1:]
         self.atoms_glucose = [
             Atom(atomic_num_i, pos_i)
-            for atomic_num_i, pos_i in zip(self.atomic_nums_glucose, self.coords_glucose, strict=False)
+            for atomic_num_i, pos_i in zip(self.atomic_nums_glucose, self.coords_glucose, strict=True)
         ]
         # no bonds for now
         self.bonds_glucose = np.array(
@@ -77,7 +77,7 @@ class TestDrawer(TestCase):
             self.atoms_glucose,
             self.atomic_nums_glucose,
             self.coords_glucose,
-            strict=False,
+            strict=True,
         ):
             assert isinstance(atom_i_drawer, Atom)
             assert atom_i_drawer == atom_i_test

--- a/tests/molara/structure/test_drawer.py
+++ b/tests/molara/structure/test_drawer.py
@@ -40,7 +40,8 @@ class TestDrawer(TestCase):
         self.atomic_nums_glucose = np.array(xyz_data_glucose[:, 0], dtype=int)
         self.coords_glucose = xyz_data_glucose[:, 1:]
         self.atoms_glucose = [
-            Atom(atomic_num_i, pos_i) for atomic_num_i, pos_i in zip(self.atomic_nums_glucose, self.coords_glucose)
+            Atom(atomic_num_i, pos_i)
+            for atomic_num_i, pos_i in zip(self.atomic_nums_glucose, self.coords_glucose, strict=False)
         ]
         # no bonds for now
         self.bonds_glucose = np.array(
@@ -76,6 +77,7 @@ class TestDrawer(TestCase):
             self.atoms_glucose,
             self.atomic_nums_glucose,
             self.coords_glucose,
+            strict=False,
         ):
             assert isinstance(atom_i_drawer, Atom)
             assert atom_i_drawer == atom_i_test

--- a/tests/molara/structure/test_molecule.py
+++ b/tests/molara/structure/test_molecule.py
@@ -53,7 +53,7 @@ class TestMolecule(TestCase):
         atomic_nums_ccl4, coords_ccl4 = self.atomic_nums_ccl4, self.coords_ccl4
         assert ccl4.draw_bonds
         assert len(ccl4.atoms) == num_atoms_ccl4
-        for atom_i, atomic_num_i, coords_i in zip(ccl4.atoms, atomic_nums_ccl4, coords_ccl4, strict=False):
+        for atom_i, atomic_num_i, coords_i in zip(ccl4.atoms, atomic_nums_ccl4, coords_ccl4, strict=True):
             assert isinstance(atom_i, Atom)
             assert atom_i.atomic_number == atomic_num_i
             assert_array_equal(atom_i.position, coords_i)
@@ -71,7 +71,7 @@ class TestMolecule(TestCase):
         atomic_nums_water, coords_water = self.atomic_nums_water, self.coords_water
         assert water.draw_bonds
         assert len(water.atoms) == num_atoms_water
-        for atom_i, atomic_num_i, coords_i in zip(water.atoms, atomic_nums_water, coords_water, strict=False):
+        for atom_i, atomic_num_i, coords_i in zip(water.atoms, atomic_nums_water, coords_water, strict=True):
             assert isinstance(atom_i, Atom)
             assert atom_i.atomic_number == atomic_num_i
             assert_array_equal(atom_i.position, coords_i)
@@ -106,7 +106,7 @@ class TestMolecule(TestCase):
         _copy = copy.copy(self.ccl4)
         assert_array_equal(_copy.atomic_numbers, self.ccl4.atomic_numbers)
         assert _copy.molar_mass == self.ccl4.molar_mass
-        for atom_copy, atom_ccl4 in zip(_copy.atoms, self.ccl4.atoms, strict=False):
+        for atom_copy, atom_ccl4 in zip(_copy.atoms, self.ccl4.atoms, strict=True):
             assert_array_equal(atom_copy.position, atom_ccl4.position)
         assert _copy.draw_bonds == self.ccl4.draw_bonds
 

--- a/tests/molara/structure/test_molecule.py
+++ b/tests/molara/structure/test_molecule.py
@@ -53,7 +53,7 @@ class TestMolecule(TestCase):
         atomic_nums_ccl4, coords_ccl4 = self.atomic_nums_ccl4, self.coords_ccl4
         assert ccl4.draw_bonds
         assert len(ccl4.atoms) == num_atoms_ccl4
-        for atom_i, atomic_num_i, coords_i in zip(ccl4.atoms, atomic_nums_ccl4, coords_ccl4):
+        for atom_i, atomic_num_i, coords_i in zip(ccl4.atoms, atomic_nums_ccl4, coords_ccl4, strict=False):
             assert isinstance(atom_i, Atom)
             assert atom_i.atomic_number == atomic_num_i
             assert_array_equal(atom_i.position, coords_i)
@@ -71,7 +71,7 @@ class TestMolecule(TestCase):
         atomic_nums_water, coords_water = self.atomic_nums_water, self.coords_water
         assert water.draw_bonds
         assert len(water.atoms) == num_atoms_water
-        for atom_i, atomic_num_i, coords_i in zip(water.atoms, atomic_nums_water, coords_water):
+        for atom_i, atomic_num_i, coords_i in zip(water.atoms, atomic_nums_water, coords_water, strict=False):
             assert isinstance(atom_i, Atom)
             assert atom_i.atomic_number == atomic_num_i
             assert_array_equal(atom_i.position, coords_i)
@@ -106,7 +106,7 @@ class TestMolecule(TestCase):
         _copy = copy.copy(self.ccl4)
         assert_array_equal(_copy.atomic_numbers, self.ccl4.atomic_numbers)
         assert _copy.molar_mass == self.ccl4.molar_mass
-        for atom_copy, atom_ccl4 in zip(_copy.atoms, self.ccl4.atoms):
+        for atom_copy, atom_ccl4 in zip(_copy.atoms, self.ccl4.atoms, strict=False):
             assert_array_equal(atom_copy.position, atom_ccl4.position)
         assert _copy.draw_bonds == self.ccl4.draw_bonds
 

--- a/tests/molara/structure/test_molecules.py
+++ b/tests/molara/structure/test_molecules.py
@@ -85,7 +85,7 @@ class TestMolecules(TestCase):
         atomic_nums_pentane, coords_pentane = self.atomic_nums_pentane, self.coords_pentane
         assert pentane.draw_bonds
         assert len(pentane.atoms) == num_atoms_pentane
-        for atom_i, atomic_num_i, coords_i in zip(pentane.atoms, atomic_nums_pentane, coords_pentane):
+        for atom_i, atomic_num_i, coords_i in zip(pentane.atoms, atomic_nums_pentane, coords_pentane, strict=False):
             assert isinstance(atom_i, Atom)
             assert atom_i.atomic_number == atomic_num_i
             assert_array_equal(atom_i.position, coords_i)
@@ -97,7 +97,7 @@ class TestMolecules(TestCase):
         atomic_nums_glucose, coords_glucose = self.atomic_nums_glucose, self.coords_glucose
         assert glucose.draw_bonds
         assert len(glucose.atoms) == num_atoms_glucose
-        for atom_i, atomic_num_i, coords_i in zip(glucose.atoms, atomic_nums_glucose, coords_glucose):
+        for atom_i, atomic_num_i, coords_i in zip(glucose.atoms, atomic_nums_glucose, coords_glucose, strict=False):
             assert isinstance(atom_i, Atom)
             assert atom_i.atomic_number == atomic_num_i
             assert_array_equal(atom_i.position, coords_i)
@@ -112,7 +112,12 @@ class TestMolecules(TestCase):
         assert isinstance(molecules_pentane, Molecule)
         assert molecules_pentane.draw_bonds
         assert len(molecules_pentane.atoms) == self.num_atoms_pentane
-        for atom_i, atomic_num_i, coords_i in zip(molecules_pentane.atoms, atomic_nums_pentane, coords_pentane):
+        for atom_i, atomic_num_i, coords_i in zip(
+            molecules_pentane.atoms,
+            atomic_nums_pentane,
+            coords_pentane,
+            strict=False,
+        ):
             assert isinstance(atom_i, Atom)
             assert atom_i.atomic_number == atomic_num_i
             assert_array_equal(atom_i.position, coords_i)
@@ -125,7 +130,12 @@ class TestMolecules(TestCase):
         assert isinstance(molecules_glucose, Molecule)
         assert molecules_glucose.draw_bonds
         assert len(molecules_glucose.atoms) == self.num_atoms_glucose
-        for atom_i, atomic_num_i, coords_i in zip(molecules_glucose.atoms, atomic_nums_glucose, coords_glucose):
+        for atom_i, atomic_num_i, coords_i in zip(
+            molecules_glucose.atoms,
+            atomic_nums_glucose,
+            coords_glucose,
+            strict=False,
+        ):
             assert isinstance(atom_i, Atom)
             assert atom_i.atomic_number == atomic_num_i
             assert_array_equal(atom_i.position, coords_i)

--- a/tests/molara/structure/test_molecules.py
+++ b/tests/molara/structure/test_molecules.py
@@ -85,7 +85,7 @@ class TestMolecules(TestCase):
         atomic_nums_pentane, coords_pentane = self.atomic_nums_pentane, self.coords_pentane
         assert pentane.draw_bonds
         assert len(pentane.atoms) == num_atoms_pentane
-        for atom_i, atomic_num_i, coords_i in zip(pentane.atoms, atomic_nums_pentane, coords_pentane, strict=False):
+        for atom_i, atomic_num_i, coords_i in zip(pentane.atoms, atomic_nums_pentane, coords_pentane, strict=True):
             assert isinstance(atom_i, Atom)
             assert atom_i.atomic_number == atomic_num_i
             assert_array_equal(atom_i.position, coords_i)
@@ -97,7 +97,7 @@ class TestMolecules(TestCase):
         atomic_nums_glucose, coords_glucose = self.atomic_nums_glucose, self.coords_glucose
         assert glucose.draw_bonds
         assert len(glucose.atoms) == num_atoms_glucose
-        for atom_i, atomic_num_i, coords_i in zip(glucose.atoms, atomic_nums_glucose, coords_glucose, strict=False):
+        for atom_i, atomic_num_i, coords_i in zip(glucose.atoms, atomic_nums_glucose, coords_glucose, strict=True):
             assert isinstance(atom_i, Atom)
             assert atom_i.atomic_number == atomic_num_i
             assert_array_equal(atom_i.position, coords_i)
@@ -116,7 +116,7 @@ class TestMolecules(TestCase):
             molecules_pentane.atoms,
             atomic_nums_pentane,
             coords_pentane,
-            strict=False,
+            strict=True,
         ):
             assert isinstance(atom_i, Atom)
             assert atom_i.atomic_number == atomic_num_i
@@ -134,7 +134,7 @@ class TestMolecules(TestCase):
             molecules_glucose.atoms,
             atomic_nums_glucose,
             coords_glucose,
-            strict=False,
+            strict=True,
         ):
             assert isinstance(atom_i, Atom)
             assert atom_i.atomic_number == atomic_num_i


### PR DESCRIPTION
The latest releases of both `numpy` (`2.1.0`) and `scipy` (`1.14.0`) have dropped support for `python3.9`.

Also, `python3.13` will be released 1st October so this PR can be considered as a preparation for the new release.