### PR TITLE
Fix bug: shifted unitcell boundaries

### DIFF
--- a/src/molara/structure/crystal.py
+++ b/src/molara/structure/crystal.py
@@ -287,7 +287,7 @@ class Crystal(Structure):
                 ],
                 dtype=np.float32,
             )
-            - self.center_of_mass
+            - self.coordinate_shift
         )
 
     @staticmethod

--- a/src/molara/structure/structure.py
+++ b/src/molara/structure/structure.py
@@ -53,6 +53,7 @@ class Structure:
         self.drawer = Drawer(self.atoms, self.bonded_pairs, self.draw_bonds)
         self.n_at = len(self.atoms)
         self.center_of_mass = self.calculate_center_of_mass()
+        self.coordinate_shift = np.zeros(3) # keeps track of coord. shifts (e.g., by recentering)
         self.geometric_center = np.mean(self.coords, axis=0)
 
     def __copy__(self: Structure) -> Structure:
@@ -88,6 +89,7 @@ class Structure:
     def center_coordinates(self: Structure) -> None:
         """Centers the structure around the center of mass."""
         self.center_of_mass = self.calculate_center_of_mass()
+        self.coordinate_shift += self.center_of_mass # change to geometric center if needed
         self.geometric_center = np.mean(self.coords, axis=0)
         for _i, atom in enumerate(self.atoms):
             position = atom.position - self.center_of_mass

--- a/tests/molara/structure/test_crystal.py
+++ b/tests/molara/structure/test_crystal.py
@@ -197,6 +197,6 @@ class TestCrystal(TestCase):
                 ],
                 dtype=np.float32,
             )
-            - self.crystal.center_of_mass
+            - self.crystal.coordinate_shift
         )
         assert_array_equal(positions, positions_comparison)


### PR DESCRIPTION
It works again. Ready to merge, @ab5424
![grafik](https://github.com/user-attachments/assets/3e2e1d9c-789b-431b-9caa-7e443531f4e5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `coordinate_shift` variable in the `Structure` class to enhance coordinate management.
  
- **Bug Fixes**
	- Improved the accuracy of unit cell boundary calculations in the `Crystal` class by updating the method for determining positions.

- **Tests**
	- Adjusted the `test_unitcell_boundaries_positions` to reflect changes in position calculations, ensuring tests align with the updated logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->