### PR TITLE
Add explicit encoding to `open`

### DIFF
--- a/develop/colors/get_colors.py
+++ b/develop/colors/get_colors.py
@@ -82,5 +82,5 @@ def get_ase_colors() -> dict[str, dict[str, tuple]]:
 if __name__ == "__main__":
     c_table = fetch_color_table()
 
-    with (Path(file_path) / "atom_colors.json").open("w") as file:
+    with (Path(file_path) / "atom_colors.json").open("w", encoding="utf-8") as file:
         json.dump(parse_color_table(c_table) | get_ase_colors(), file)

--- a/develop/periodic_table/get_pd_data.py
+++ b/develop/periodic_table/get_pd_data.py
@@ -35,10 +35,10 @@ def fetch_license() -> str:
 
 if __name__ == "__main__":
     pt_data = fetch_periodic_table()
-    with (file_path / "periodic_table.json").open(mode="w") as file:
+    with (file_path / "periodic_table.json").open(mode="w", encoding="utf-8") as file:
         json.dump(pt_data, file)
 
     license_text = fetch_license()
-    with (file_path / "periodic_table_copyright").open(mode="w") as file:
+    with (file_path / "periodic_table_copyright").open(mode="w", encoding="utf-8") as file:
         file.write("Periodic Table data from pymatgen.\nThe data is licensed under the following terms:\n\n")
         file.write(license_text)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,6 @@ target-version = "py310"
 line-length = 120
 lint.select = ["ALL"]
 lint.ignore = [
-  "ANN101", # Missing type annotation for `self` in method
   "ERA001", # Found commented-out code
   "D203",   # 1 blank line required before class docstring (incompatible with D211)
   "D213",   # Multi-line docstring summary should start at the second line (incompatible with D212)

--- a/src/molara/gui/export_image_dialog.py
+++ b/src/molara/gui/export_image_dialog.py
@@ -75,7 +75,7 @@ class ExportImageDialog(QDialog):
 
     def make_background_transparent(self) -> None:
         """Set the background of the image to be transparent."""
-        image = Image.open(self.ui.filenameInput.text())
+        image = Image.open(self.ui.filenameInput.text(), "r")
         image = image.convert("RGBA")
         image_data = np.array(image)
         # Create a mask for white pixels (where R=255, G=255, B=255)

--- a/src/molara/gui/structure_customizer_dialog.py
+++ b/src/molara/gui/structure_customizer_dialog.py
@@ -110,7 +110,7 @@ class StructureCustomizerDialog(QDialog):
         if not save_name:
             save_name = self.ui.loadSelect.currentText()
         settings_file = f"{self.home_path}/settings/structure/{save_name}.json"
-        with Path(settings_file).open() as f:
+        with Path(settings_file).open("r", encoding="utf-8") as f:
             settings = json.load(f)
         self.load_settings_dict(settings)
         if self.parent().structure_widget.structures:
@@ -161,7 +161,7 @@ class StructureCustomizerDialog(QDialog):
         else:
             settings = self.create_settings_dict()
             settings_file = f"{self.home_path}/settings/structure/{save_name}.json"
-            with Path(settings_file).open("w") as f:
+            with Path(settings_file).open("w", encoding="utf-8") as f:
                 json.dump(settings, f)
         self.update_settings_box()
 

--- a/src/molara/rendering/camera.py
+++ b/src/molara/rendering/camera.py
@@ -332,7 +332,7 @@ class Camera:
         }
         if not file_name.endswith(".json"):
             file_name += ".json"
-        with Path(file_name).open("w") as file:
+        with Path(file_name).open("w", encoding="utf-8") as file:
             json.dump(settings, file, indent=4)
 
     def import_settings(self, file_name: str) -> None:
@@ -343,7 +343,7 @@ class Camera:
         if not file_name.endswith(".json"):
             # Show warning
             return
-        with Path(file_name).open() as file:
+        with Path(file_name).open("r", encoding="utf-8") as file:
             data = json.load(file)
         self.orthographic_projection = data["orthographic_projection"]
         self.fov = data["fov"]

--- a/src/molara/structure/io/exporter.py
+++ b/src/molara/structure/io/exporter.py
@@ -49,7 +49,7 @@ class XyzExporter(StructureExporter):
             for atom in structure.atoms
         ]
         try:
-            with self.path.open("w") as file:
+            with self.path.open("w", encoding="utf-8") as file:
                 file.write(rf"{len(structure.atoms)}" + "\n")
                 file.write("This xyz file was generated automatically by Molara!\n")
                 file.write("\n".join(lines))

--- a/src/molara/structure/io/importer.py
+++ b/src/molara/structure/io/importer.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import locale
 import re
 from abc import ABC, abstractmethod
 from fnmatch import fnmatch
@@ -111,7 +110,7 @@ class CoordImporter(MoleculesImporter):
         """Read the file in self.path and creates a Molecules object."""
         molecules = Molecules()
 
-        with self.path.open(encoding=locale.getpreferredencoding(do_setlocale=False)) as file:
+        with self.path.open(encoding="utf-8") as file:
             lines = file.readlines()  # To skip first row
 
         atomic_numbers = []
@@ -149,7 +148,7 @@ class MoldenImporter(MoleculesImporter):
         spherical_order = "none"
         normalization_mode = "none"
 
-        with self.path.open(encoding=locale.getpreferredencoding(do_setlocale=False)) as file:
+        with self.path.open(encoding="utf-8") as file:
             lines = file.readlines()
 
         while i < len(lines):
@@ -378,7 +377,7 @@ class CubeImporter(MoleculesImporter):
         """Read the file in self.path and creates a Molecules object."""
         molecules = Molecules()
 
-        with self.path.open(encoding=locale.getpreferredencoding(do_setlocale=False)) as file:
+        with self.path.open(encoding="utf-8") as file:
             lines = file.readlines()
 
         # Get number of atoms and position of the origin

--- a/tests/molara/gui/test_main_window.py
+++ b/tests/molara/gui/test_main_window.py
@@ -273,7 +273,7 @@ class WorkaroundTestMainWindow:
 
         assert Path("~/.molara/settings/structure").expanduser().exists()
         assert Path("~/.molara/settings/structure/Default.json").expanduser().exists()
-        with Path("~/.molara/settings/structure/Default.json").expanduser().open() as file:
+        with Path("~/.molara/settings/structure/Default.json").expanduser().open("r", encoding="utf-8") as file:
             assert file.read() == (
                 '{"stick_mode": false, "bonds": true, "ball_size": 1.0, "stick_size": 1.0, '
                 '"atom_numbers": false, "atom_numbers_size": 1.0, "color_scheme": "CPK"}'

--- a/tests/molara/rendering/test_camera.py
+++ b/tests/molara/rendering/test_camera.py
@@ -158,7 +158,7 @@ class TestCamera(TestCase):
         camera.export_settings(filename)
 
         assert Path(filename).exists()
-        with Path(filename).open() as file:
+        with Path(filename).open("r", encoding="utf-8") as file:
             data = json.load(file)
 
         # check if settings are correct

--- a/tests/molara/structure/io/test_exporter.py
+++ b/tests/molara/structure/io/test_exporter.py
@@ -47,7 +47,7 @@ class TestXyzExporter(unittest.TestCase):
         assert Path(self.filename).exists()
 
         # Assert that the output file has the expected content
-        with Path(self.filename).open() as file:
+        with Path(self.filename).open("r", encoding="utf-8") as file:
             num_atoms = int(file.readline().strip())
             assert num_atoms == self.atomic_numbers.size
         data = np.genfromtxt(
@@ -93,7 +93,7 @@ class TestGeneralExporter(unittest.TestCase):
         assert Path(self.filename_xyz).exists()
 
         # Assert that the output file has the expected content
-        with Path(self.filename_xyz).open() as file:
+        with Path(self.filename_xyz).open("r", encoding="utf-8") as file:
             num_atoms = int(file.readline().strip())
             assert num_atoms == self.atomic_numbers.size
         data = np.genfromtxt(

--- a/tests/molara/structure/io/test_importer.py
+++ b/tests/molara/structure/io/test_importer.py
@@ -112,7 +112,7 @@ class TestQmImporter(TestCase):
             return
         with NamedTemporaryFile(suffix=".txt") as file:
             filename = file.name
-        with Path(filename).open("w") as file:
+        with Path(filename).open("w", encoding="utf-8") as file:
             file.write("Invalid content!")
         msg = "Not a QM output file."
         with pytest.raises(FileFormatError, match=msg):


### PR DESCRIPTION
This will become default in python 3.15 (see https://peps.python.org/pep-0686/). It will also soon be enforced by `ruff` (https://docs.astral.sh/ruff/rules/unspecified-encoding/)